### PR TITLE
Ecs mutable component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ node_modules
 *.out
 *.pdf
 *.ps
+
+# Bazel
+.bazelrc.user

--- a/nova/server.ts
+++ b/nova/server.ts
@@ -84,7 +84,7 @@ async function startGame() {
     // TODO: Don't just give the server the 'server' uuid
     const multiplayerPlugin = multiplayer(communicator);
 
-    world.addResource(GameDataResource, gameData);
+    world.resources.set(GameDataResource, gameData);
     world.addPlugin(multiplayerPlugin);
     world.addPlugin(ServerPlugin);
     world.addPlugin(Nova);

--- a/nova/src/browser.ts
+++ b/nova/src/browser.ts
@@ -66,7 +66,7 @@ async function startGame() {
     //shipController = new ShipController(controller);
     const multiplayerPlugin = multiplayer(communicator);
 
-    world.addResource(GameDataResource, gameData);
+    world.resources.set(GameDataResource, gameData);
     world.addPlugin(multiplayerPlugin);
     world.addPlugin(Nova);
     world.addPlugin(Display);

--- a/nova/src/display/display_plugin.ts
+++ b/nova/src/display/display_plugin.ts
@@ -3,6 +3,8 @@ import { System } from "nova_ecs/system";
 import { Plugin } from "nova_ecs/plugin";
 import * as PIXI from "pixi.js";
 import { TimeResource } from "nova_ecs/plugins/time_plugin";
+import { Component } from "nova_ecs/component";
+import { EntityBuilder } from "nova_ecs/entity";
 
 
 export const PixiContainer = new Resource<PIXI.Container>({
@@ -12,10 +14,8 @@ export const PixiContainer = new Resource<PIXI.Container>({
 });
 
 
-const SquareGraphics = new Resource<PIXI.Graphics>({
+const SquareGraphics = new Component<PIXI.Graphics>({
     name: 'SquareGraphics',
-    multiplayer: false,
-    mutable: true,
 });
 
 const SquareSystem = new System({
@@ -40,7 +40,9 @@ export const Display: Plugin = {
 
         container.addChild(squareGraphics);
         world.resources.set(PixiContainer, container);
-        world.resources.set(SquareGraphics, squareGraphics);
+        world.entities.set('square1', new EntityBuilder()
+            .addComponent(SquareGraphics, squareGraphics)
+            .build());
         world.addSystem(SquareSystem);
     }
 }

--- a/nova/src/display/display_plugin.ts
+++ b/nova/src/display/display_plugin.ts
@@ -39,8 +39,8 @@ export const Display: Plugin = {
         squareGraphics.endFill();
 
         container.addChild(squareGraphics);
-        world.addResource(PixiContainer, container);
-        world.addResource(SquareGraphics, squareGraphics);
+        world.resources.set(PixiContainer, container);
+        world.resources.set(SquareGraphics, squareGraphics);
         world.addSystem(SquareSystem);
     }
 }

--- a/nova_ecs/BUILD.bazel
+++ b/nova_ecs/BUILD.bazel
@@ -20,6 +20,7 @@ ts_library(
         "async_system.ts",
         "component_map.ts",
         "entity_map.ts",
+        "resource_map.ts",
         "mutable_immutable_map_handle.ts",
     ],
     deps = [
@@ -61,7 +62,6 @@ pkg_npm(
     srcs = ["package.json"],
     deps = [
         ":ecs",
-        "//:.gitignore",
     ],
     nested_packages = [
         "//nova_ecs/datatypes:datatypes_pkg",

--- a/nova_ecs/async_system.ts
+++ b/nova_ecs/async_system.ts
@@ -99,7 +99,7 @@ export class AsyncSystem<StepArgTypes extends readonly ArgTypes[] = readonly Arg
 export const AsyncSystemPlugin: Plugin = {
     name: 'AsyncSystem',
     build: (world) => {
-        world.addResource(AsyncSystemData, {
+        world.resources.set(AsyncSystemData, {
             done: Promise.resolve(),
             systems: new DefaultMap<string /* system name */,
                 DefaultMap<string /* entity uuid */, {

--- a/nova_ecs/async_system_test.ts
+++ b/nova_ecs/async_system_test.ts
@@ -1,7 +1,7 @@
 import 'jasmine';
 import { v4 } from 'uuid';
 import { Entities, UUID } from './arg_types';
-import { AsyncSystem, AsyncSystemData } from './async_system';
+import { AsyncSystem, AsyncSystemResource } from './async_system';
 import { Component, ComponentData } from './component';
 import { Angle } from './datatypes/angle';
 import { Vector } from './datatypes/vector';
@@ -63,7 +63,7 @@ describe('async system', () => {
         world.addSystem(asyncSystem);
         world.step();
         clock.tick(1);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
 
         expect(handle.components.get(BAR_COMPONENT)?.y)
@@ -97,7 +97,7 @@ describe('async system', () => {
         world.addSystem(removeBarSystem);
         world.step();
         clock.tick(1);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
         expect(world.entities.has(uuid)).toBeFalse();
     });
@@ -122,12 +122,12 @@ describe('async system', () => {
         world.step();
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
         world.step();
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
 
         expect(fooValues).toEqual([1, 1, 1, 2, 2, 2]);
     });
@@ -153,7 +153,7 @@ describe('async system', () => {
 
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
 
         expect(world.entities.get('test uuid')?.components
@@ -190,7 +190,7 @@ describe('async system', () => {
         world.singletonEntity.components.set(addedMovement, { added: false });
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
 
         expect(world.entities.get('movable')?.components.get(MovementComponent))
@@ -226,13 +226,13 @@ describe('async system', () => {
         world.step();
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
         world.step();
         world.step();
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
 
         expect(fooValues).toEqual([1, 2, 3, 1, 2, 3, 4]);
     });
@@ -258,7 +258,7 @@ describe('async system', () => {
 
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
 
         expect(fooValues).toEqual([123, 456, 123, 456]);
@@ -284,7 +284,7 @@ describe('async system', () => {
 
         world.step();
         clock.tick(11);
-        await world.resources.get(AsyncSystemData)?.done;
+        await world.resources.get(AsyncSystemResource)?.done;
         world.step();
 
         // With a synchronous system, we'd expect each foo compoent to be incremented

--- a/nova_ecs/component_map.ts
+++ b/nova_ecs/component_map.ts
@@ -18,7 +18,7 @@ export class ComponentMapHandle
     extends MutableImmutableMapHandle<UnknownComponent, unknown>
     implements ComponentMap {
 
-    constructor(private entityUuid: string, callWithDraft: CallWithDraft,
+    constructor(private entityUuid: string, callWithDraft: CallWithDraft<State>,
         private addComponent: (component: Component<any, any, any, any>) => void) {
         super(new Map(), (callback) => callWithDraft(
             draft => callback(this.getEntityComponents(draft))),

--- a/nova_ecs/component_map.ts
+++ b/nova_ecs/component_map.ts
@@ -20,9 +20,8 @@ export class ComponentMapHandle
 
     constructor(private entityUuid: string, callWithDraft: CallWithDraft<State>,
         private addComponent: (component: Component<any, any, any, any>) => void) {
-        super(new Map(), (callback) => callWithDraft(
+        super((callback) => callWithDraft(
             draft => callback(this.getEntityComponents(draft))),
-            component => component.mutable,
             currentIfDraft);
     }
 

--- a/nova_ecs/entity_map.ts
+++ b/nova_ecs/entity_map.ts
@@ -1,13 +1,13 @@
 import { Component } from "./component";
 import { ComponentMapHandle } from "./component_map";
 import { Entity } from "./entity";
-import { CallWithDraft } from "./world";
+import { CallWithDraft, State } from "./world";
 
 export interface EntityMap extends Map<string, Entity> { }
 
 export class EntityMapHandle implements EntityMap {
     constructor(private mutableEntities: EntityMap,
-        private callWithDraft: CallWithDraft,
+        private callWithDraft: CallWithDraft<State>,
         // addComponnet adds a component as something the world knows about.
         // Doesn't add it to an entity.
         private addComponent: (component: Component<any, any, any, any>) => void) { }

--- a/nova_ecs/entity_map.ts
+++ b/nova_ecs/entity_map.ts
@@ -6,14 +6,12 @@ import { CallWithDraft, State } from "./world";
 export interface EntityMap extends Map<string, Entity> { }
 
 export class EntityMapHandle implements EntityMap {
-    constructor(private mutableEntities: EntityMap,
-        private callWithDraft: CallWithDraft<State>,
+    constructor(private callWithDraft: CallWithDraft<State>,
         // addComponnet adds a component as something the world knows about.
         // Doesn't add it to an entity.
         private addComponent: (component: Component<any, any, any, any>) => void) { }
 
     clear(): void {
-        this.mutableEntities.clear();
         this.callWithDraft(draft => {
             draft.entities.clear();
         });

--- a/nova_ecs/plugins/time_plugin.ts
+++ b/nova_ecs/plugins/time_plugin.ts
@@ -37,7 +37,7 @@ export const TimeSystem = new System({
 export const TimePlugin: Plugin = {
     name: 'time',
     build: (world) => {
-        world.addResource(TimeResource,
+        world.resources.set(TimeResource,
             { delta_ms: 0, delta_s: 0, time: new Date().getTime() });
         world.addSystem(TimeSystem);
         world.singletonEntity.components.set(TimeSingleton, undefined);

--- a/nova_ecs/resource.ts
+++ b/nova_ecs/resource.ts
@@ -18,12 +18,10 @@ export class Resource<Data, DataSerialized = Data,
     Component<Data, DataSerialized, Delta, DeltaSerialized> {
 
     readonly multiplayer: boolean;
-    readonly mutable: boolean;
-    constructor({ name, type, getDelta, applyDelta, multiplayer, mutable }:
+    constructor({ name, type, getDelta, applyDelta, multiplayer }:
         ResourceArgs<Data, DataSerialized, Delta, DeltaSerialized>) {
         super({ name, type, getDelta, applyDelta });
         this.multiplayer = multiplayer ?? true;
-        this.mutable = mutable ?? false;
     }
 
     toString() {

--- a/nova_ecs/resource_map.ts
+++ b/nova_ecs/resource_map.ts
@@ -16,7 +16,9 @@ export interface ResourceMap extends Map<UnknownResource, unknown> {
 export class ResourceMapHandle
     extends MutableImmutableMapHandle<UnknownResource, unknown>
     implements ResourceMap {
-    constructor(callWithDraft: CallWithDraft, mutableResources: ResourceMap) {
+    constructor(mutableResources: ResourceMap,
+        callWithDraft: CallWithDraft,
+        private addResource: (resource: Resource<any, any, any, any>) => void) {
         super(mutableResources, (callback) => callWithDraft(
             draft => callback(draft.resources)),
             resource => resource.mutable,
@@ -28,10 +30,13 @@ export class ResourceMapHandle
     };
 
     set<Data>(resource: Resource<Data, any, any, any>, data: Data): this {
+        this.addResource(resource);
         return super.set(resource as UnknownResource, data);
     };
 
-    delete(resource: Resource<any, any, any, any>): boolean {
-        return super.delete(resource as UnknownResource);
+    delete(_resource: Resource<any, any, any, any>): boolean {
+        throw new Error('Resources can not be deleted since a system may depend on them');
+        // TODO: Allow deletion of resources. Check the systems.
+        //return super.delete(resource as UnknownResource);
     };
 }

--- a/nova_ecs/resource_map.ts
+++ b/nova_ecs/resource_map.ts
@@ -16,13 +16,11 @@ export interface ResourceMap extends Map<UnknownResource, unknown> {
 export class ResourceMapHandle
     extends MutableImmutableMapHandle<UnknownResource, unknown>
     implements ResourceMap {
-    constructor(mutableResources: ResourceMap,
-        callWithDraft: CallWithDraft<State>,
+    constructor(callWithDraft: CallWithDraft<State>,
         private addResource: (resource: Resource<any, any, any, any>) => void) {
-        super(mutableResources, (callback) => callWithDraft(
+        super((callback) => callWithDraft(
             draft => callback(draft.resources)),
-            resource => resource.mutable,
-            currentIfDraft)
+            currentIfDraft);
     }
 
     get<Data>(resource: Resource<Data, any, any, any>): Data | undefined {

--- a/nova_ecs/resource_map.ts
+++ b/nova_ecs/resource_map.ts
@@ -1,0 +1,37 @@
+import { Resource, UnknownResource } from "./resource";
+import { MutableImmutableMapHandle } from "./mutable_immutable_map_handle";
+import { currentIfDraft } from "./utils";
+import { CallWithDraft, State } from "./world";
+
+export interface ReadonlyResourceMap extends ReadonlyMap<UnknownResource, unknown> {
+    get<Data>(resource: Resource<Data, any, any, any>): Data | undefined;
+}
+
+export interface ResourceMap extends Map<UnknownResource, unknown> {
+    get<Data>(resource: Resource<Data, any, any, any>): Data | undefined;
+    set<Data>(resource: Resource<Data, any, any, any>, data: Data): this;
+    delete(resource: Resource<any, any, any, any>): boolean;
+}
+
+export class ResourceMapHandle
+    extends MutableImmutableMapHandle<UnknownResource, unknown>
+    implements ResourceMap {
+    constructor(callWithDraft: CallWithDraft, mutableResources: ResourceMap) {
+        super(mutableResources, (callback) => callWithDraft(
+            draft => callback(draft.resources)),
+            resource => resource.mutable,
+            currentIfDraft)
+    }
+
+    get<Data>(resource: Resource<Data, any, any, any>): Data | undefined {
+        return super.get(resource as UnknownResource) as Data;
+    };
+
+    set<Data>(resource: Resource<Data, any, any, any>, data: Data): this {
+        return super.set(resource as UnknownResource, data);
+    };
+
+    delete(resource: Resource<any, any, any, any>): boolean {
+        return super.delete(resource as UnknownResource);
+    };
+}

--- a/nova_ecs/resource_map.ts
+++ b/nova_ecs/resource_map.ts
@@ -17,7 +17,7 @@ export class ResourceMapHandle
     extends MutableImmutableMapHandle<UnknownResource, unknown>
     implements ResourceMap {
     constructor(mutableResources: ResourceMap,
-        callWithDraft: CallWithDraft,
+        callWithDraft: CallWithDraft<State>,
         private addResource: (resource: Resource<any, any, any, any>) => void) {
         super(mutableResources, (callback) => callWithDraft(
             draft => callback(draft.resources)),

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -66,21 +66,11 @@ export class World {
         resources: new Map(),
     };
 
-    // Note that an entity may appear in both the immutable state
-    // and the mutable state since it may have both immutable and
-    // mutable components.
-    private mutableState: State = {
-        entities: new Map(),
-        resources: new Map(),
-    };
-
     readonly entities = new EntityMapHandle(
-        this.mutableState.entities,
         this.callWithNewDraft.bind(this),
         this.addComponent.bind(this));
 
-    resources = new ResourceMapHandle(
-        this.mutableState.resources,
+    readonly resources = new ResourceMapHandle(
         this.callWithNewDraft.bind(this),
         this.addResource.bind(this));
 
@@ -133,8 +123,7 @@ export class World {
 
     addSystem(system: System): this {
         for (const resource of system.resources) {
-            if (!this.state.resources.has(resource)
-                && !this.mutableState.resources.has(resource)) {
+            if (!this.state.resources.has(resource)) {
                 throw new Error(
                     `World is missing ${resource} needed for ${system}`);
             }
@@ -215,8 +204,6 @@ export class World {
         if (arg instanceof Resource) {
             if (draft.resources.has(arg)) {
                 return draft.resources.get(arg) as ResourceData<T> | undefined;
-            } else if (this.mutableState.resources.has(arg)) {
-                return this.mutableState.resources.get(arg) as ResourceData<T> | undefined;
             } else {
                 throw new Error(`Missing resource ${arg}`);
             }

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -58,10 +58,6 @@ export interface State {
 
 export type CallWithDraft = <R>(callback: (draft: Draft<State>) => R) => R;
 
-interface ReadonlyResourceMap extends ReadonlyMap<UnknownResource, unknown> {
-    get<Data>(resource: Resource<Data, any, any, any>): Data | undefined;
-}
-
 enableMapSet();
 
 export class World {
@@ -86,7 +82,7 @@ export class World {
     resources = new ResourceMapHandle(
         this.mutableState.resources,
         this.callWithNewDraft.bind(this),
-        this.updateResourceMap.bind(this));
+        this.addResource.bind(this));
 
     // These maps exist in part to make sure there are no name collisions
     private nameComponentMap = new Map<string, UnknownComponent>();
@@ -127,15 +123,7 @@ export class World {
         return result!;
     }
 
-    /**
-     * Add a resource to the world.
-     * @deprecated Use world.resources.set instead
-     */
-    addResource<Data>(resource: Resource<Data, any, any, any>, value: Data) {
-        this.resources.set(resource, value);
-    }
-
-    private updateResourceMap(resource: Resource<any, any, any, any>) {
+    private addResource(resource: Resource<any, any, any, any>) {
         if (this.nameResourceMap.has(resource.name)
             && this.nameResourceMap.get(resource.name) !== resource) {
             throw new Error(`A resource with name ${resource.name} already exists`);

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -7,6 +7,7 @@ import { EntityMap, EntityMapHandle } from "./entity_map";
 import { Plugin } from './plugin';
 import { Query } from "./query";
 import { Resource, ResourceData, UnknownResource } from "./resource";
+import { ResourceMap, ResourceMapHandle } from "./resource_map";
 import { System } from "./system";
 import { topologicalSort } from './utils';
 
@@ -52,7 +53,7 @@ enablePatches();
 
 export interface State {
     entities: EntityMap;
-    resources: Map<UnknownResource, unknown>;
+    resources: ResourceMap;
 }
 
 export type CallWithDraft = <R>(callback: (draft: Draft<State>) => R) => R;
@@ -82,12 +83,15 @@ export class World {
         this.callWithNewDraft.bind(this),
         this.addComponent.bind(this));
 
-    get resources() {
-        return new Map([
-            ...this.state.resources,
-            ...this.mutableState.resources,
-        ]) as ReadonlyResourceMap;
-    }
+    // get resources() {
+    //     return new Map([
+    //         ...this.state.resources,
+    //         ...this.mutableState.resources,
+    //     ]) as ReadonlyResourceMap;
+    // }
+
+    resources = new ResourceMapHandle(this.callWithNewDraft.bind(this),
+        this.mutableState.resources);
 
     // These maps exist in part to make sure there are no name collisions
     private nameComponentMap = new Map<string, UnknownComponent>();

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -83,15 +83,10 @@ export class World {
         this.callWithNewDraft.bind(this),
         this.addComponent.bind(this));
 
-    // get resources() {
-    //     return new Map([
-    //         ...this.state.resources,
-    //         ...this.mutableState.resources,
-    //     ]) as ReadonlyResourceMap;
-    // }
-
-    resources = new ResourceMapHandle(this.callWithNewDraft.bind(this),
-        this.mutableState.resources);
+    resources = new ResourceMapHandle(
+        this.mutableState.resources,
+        this.callWithNewDraft.bind(this),
+        this.updateResourceMap.bind(this));
 
     // These maps exist in part to make sure there are no name collisions
     private nameComponentMap = new Map<string, UnknownComponent>();
@@ -132,15 +127,12 @@ export class World {
         return result!;
     }
 
-    // TODO: Resource map like entities
+    /**
+     * Add a resource to the world.
+     * @deprecated Use world.resources.set instead
+     */
     addResource<Data>(resource: Resource<Data, any, any, any>, value: Data) {
-        if (resource.mutable) {
-            this.updateResourceMap(resource);
-            this.mutableState.resources.set(resource as UnknownResource, value);
-        } else {
-            this.addResourceToDraft(resource, value,
-                this.callWithNewDraft.bind(this));
-        }
+        this.resources.set(resource, value);
     }
 
     private updateResourceMap(resource: Resource<any, any, any, any>) {
@@ -149,15 +141,6 @@ export class World {
             throw new Error(`A resource with name ${resource.name} already exists`);
         }
         this.nameResourceMap.set(resource.name, resource as UnknownResource);
-    }
-
-    private addResourceToDraft<Data>(resource: Resource<Data, any, any, any>,
-        value: Data, callWithDraft: CallWithDraft) {
-        this.updateResourceMap(resource);
-        // TODO: Fix these types. Maybe pass resources in the World constructor?
-        callWithDraft(draft => {
-            draft.resources.set(resource as UnknownResource, value);
-        });
     }
 
     addSystem(system: System): this {

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -56,7 +56,7 @@ export interface State {
     resources: ResourceMap;
 }
 
-export type CallWithDraft = <R>(callback: (draft: Draft<State>) => R) => R;
+export type CallWithDraft<T> = <R>(callback: (draft: Draft<T>) => R) => R;
 
 enableMapSet();
 

--- a/nova_ecs/world_test.ts
+++ b/nova_ecs/world_test.ts
@@ -56,6 +56,14 @@ const FOO_BAR_SYSTEM = new System({
     }
 });
 
+class MutableObject {
+    constructor(public val: string) { }
+}
+
+const MUTABLE_COMPONENT = new Component<MutableObject>({
+    name: 'MutableComponent'
+})
+
 describe('world', () => {
     let world: World;
     beforeEach(() => {
@@ -819,9 +827,8 @@ describe('world', () => {
     });
 
     it('supports mutable resources', () => {
-        const MutableResource = new Resource<{ val: string }>({
+        const MutableResource = new Resource<MutableObject>({
             name: 'MutableResource',
-            mutable: true,
         });
 
         const changeResourceSystem = new System({
@@ -832,38 +839,33 @@ describe('world', () => {
             }
         });
 
-        const resourceVal = { val: 'unchanged' };
+        const resourceVal = new MutableObject('unchanged');
         world.resources.set(MutableResource, resourceVal);
         world.addSystem(changeResourceSystem);
 
         world.step();
 
-        expect(resourceVal).toEqual({ val: 'changed' });
+        expect(resourceVal).toEqual(new MutableObject('changed'));
     });
 
-    xit('supports mutable components', () => {
-        const MutableComponent = new Component<{ val: string }>({
-            name: 'MutableComponent',
-            mutable: true,
-        });
-
+    it('supports mutable components', () => {
         const changeComponentSystem = new System({
             name: 'ChangeComponentSystem',
-            args: [MutableComponent],
+            args: [MUTABLE_COMPONENT],
             step: (mutableComponent) => {
                 mutableComponent.val = 'changed';
             }
         });
 
-        const componentVal = { val: 'unchanged' };
+        const componentVal = new MutableObject('unchanged');
         world.entities.set('example uuid', new EntityBuilder()
-            .addComponent(MutableComponent, { val: 'unchanged' })
+            .addComponent(MUTABLE_COMPONENT, componentVal)
             .build());
 
         world.addSystem(changeComponentSystem);
 
         world.step();
 
-        expect(componentVal).toEqual({ val: 'changed' });
+        expect(componentVal).toEqual(new MutableObject('changed'));
     });
 });

--- a/nova_ecs/world_test.ts
+++ b/nova_ecs/world_test.ts
@@ -175,7 +175,7 @@ describe('world', () => {
             }
         });
 
-        world.addResource(BAZ_RESOURCE, { z: ['foo', 'bar'] });
+        world.resources.set(BAZ_RESOURCE, { z: ['foo', 'bar'] });
         world.addSystem(testSystem);
         world.entities.set(v4(), new EntityBuilder()
             .addComponent(FOO_COMPONENT, { x: 123 }));
@@ -195,7 +195,7 @@ describe('world', () => {
             }
         });
 
-        world.addResource(BAZ_RESOURCE, { z: ['foo', 'bar'] });
+        world.resources.set(BAZ_RESOURCE, { z: ['foo', 'bar'] });
         world.addSystem(testSystem);
         world.entities.set('entityUuid', new EntityBuilder()
             .addComponent(FOO_COMPONENT, { x: 123 }));
@@ -566,8 +566,8 @@ describe('world', () => {
             applyDelta: () => { },
         });
 
-        world.addResource(resource1, 'foobar');
-        expect(() => world.addResource(resource2, 'foobar'))
+        world.resources.set(resource1, 'foobar');
+        expect(() => world.resources.set(resource2, 'foobar'))
             .toThrowError(`A resource with name ${resource2.name} already exists`);
     });
 
@@ -833,7 +833,7 @@ describe('world', () => {
         });
 
         const resourceVal = { val: 'unchanged' };
-        world.addResource(MutableResource, resourceVal);
+        world.resources.set(MutableResource, resourceVal);
         world.addSystem(changeResourceSystem);
 
         world.step();

--- a/nova_ecs/world_test.ts
+++ b/nova_ecs/world_test.ts
@@ -817,4 +817,53 @@ describe('world', () => {
         expect(handle.components.get(BAR_COMPONENT)?.y)
             .toEqual('changed bar');
     });
+
+    it('supports mutable resources', () => {
+        const MutableResource = new Resource<{ val: string }>({
+            name: 'MutableResource',
+            mutable: true,
+        });
+
+        const changeResourceSystem = new System({
+            name: 'ChangeResourceSystem',
+            args: [MutableResource],
+            step: (mutableResource) => {
+                mutableResource.val = 'changed';
+            }
+        });
+
+        const resourceVal = { val: 'unchanged' };
+        world.addResource(MutableResource, resourceVal);
+        world.addSystem(changeResourceSystem);
+
+        world.step();
+
+        expect(resourceVal).toEqual({ val: 'changed' });
+    });
+
+    xit('supports mutable components', () => {
+        const MutableComponent = new Component<{ val: string }>({
+            name: 'MutableComponent',
+            mutable: true,
+        });
+
+        const changeComponentSystem = new System({
+            name: 'ChangeComponentSystem',
+            args: [MutableComponent],
+            step: (mutableComponent) => {
+                mutableComponent.val = 'changed';
+            }
+        });
+
+        const componentVal = { val: 'unchanged' };
+        world.entities.set('example uuid', new EntityBuilder()
+            .addComponent(MutableComponent, { val: 'unchanged' })
+            .build());
+
+        world.addSystem(changeComponentSystem);
+
+        world.step();
+
+        expect(componentVal).toEqual({ val: 'changed' });
+    });
 });


### PR DESCRIPTION
Remove mutable components and resources as separate from the immutable state tree because the immutable state tree actually already allows mutable objects in it (immer only drafts an object if it's immerable).