### PR TITLE
Implement events and create the delete event

### DIFF
--- a/nova_ecs/BUILD.bazel
+++ b/nova_ecs/BUILD.bazel
@@ -25,11 +25,14 @@ ts_library(
         "modifier.ts",
         "optional.ts",
         "provider.ts",
+        "events.ts",
+        "event_map.ts",
     ],
     deps = [
         "@npm//io-ts",
         "@npm//fp-ts",
         "@npm//immer",
+        "@npm//rxjs",
     ]
 )
 

--- a/nova_ecs/component.ts
+++ b/nova_ecs/component.ts
@@ -1,4 +1,4 @@
-import { Draft, immerable } from 'immer';
+import { Draft } from 'immer';
 import * as t from 'io-ts';
 
 export type ComponentData<C> = C extends Component<infer Data, any, any, any> ? Data : never;

--- a/nova_ecs/event_map.ts
+++ b/nova_ecs/event_map.ts
@@ -1,0 +1,58 @@
+import { immerable } from 'immer';
+import { Subject } from 'rxjs';
+
+/**
+ * A map that emits events when its contents are changed.
+ */
+export class EventMap<K, V> implements Map<K, V> {
+    [immerable] = true;
+    // The wrapped map that stores the data. Don't extend
+    // the map class because immer will replace it with a
+    // generic 'map' object when running produce.
+    private readonly wrappedMap = new Map<K, V>();
+
+    // TODO(mattsoulanille): Add more events.
+    readonly events = {
+        delete: new Subject<Set<K>>(),
+    }
+
+    clear(): void {
+        this.events.delete.next(new Set([...this.keys()]));
+        this.wrappedMap.clear();
+    }
+    forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void {
+        return this.wrappedMap.forEach(callbackfn, thisArg);
+    }
+    get(key: K): V | undefined {
+        return this.wrappedMap.get(key);
+    }
+    has(key: K): boolean {
+        return this.wrappedMap.has(key);
+    }
+    set(key: K, value: V): this {
+        this.wrappedMap.set(key, value);
+        return this;
+    }
+    delete(key: K) {
+        if (this.wrappedMap.has(key)) {
+            this.events.delete.next(new Set([key]));
+        }
+        return this.wrappedMap.delete(key);
+    }
+    get size() {
+        return this.wrappedMap.size;
+    }
+    [Symbol.iterator](): IterableIterator<[K, V]> {
+        return this.wrappedMap[Symbol.iterator]();
+    }
+    entries(): IterableIterator<[K, V]> {
+        return this.wrappedMap.entries();
+    }
+    keys(): IterableIterator<K> {
+        return this.wrappedMap.keys();
+    }
+    values(): IterableIterator<V> {
+        return this.wrappedMap.values();
+    }
+    [Symbol.toStringTag]: string;
+}

--- a/nova_ecs/events.ts
+++ b/nova_ecs/events.ts
@@ -1,0 +1,3 @@
+export const StepEvent = Symbol('step');
+export const DeleteEvent = Symbol('delete');
+

--- a/nova_ecs/system.ts
+++ b/nova_ecs/system.ts
@@ -1,4 +1,5 @@
 import { ArgsToData, ArgTypes } from "./arg_types";
+import { StepEvent } from "./events";
 import { Query } from "./query";
 
 
@@ -7,6 +8,7 @@ export interface BaseSystemArgs<StepArgTypes extends readonly ArgTypes[]> {
     readonly args: StepArgTypes;
     readonly before?: Iterable<System | string>; // Systems that this system runs before
     readonly after?: Iterable<System | string>; // Systems that this system runs after
+    readonly event?: Symbol;
 }
 export interface SystemArgs<StepArgTypes extends readonly ArgTypes[]> extends BaseSystemArgs<StepArgTypes> {
     step: (...args: ArgsToData<StepArgTypes>) => void;
@@ -18,14 +20,16 @@ export class System<StepArgTypes extends readonly ArgTypes[] = readonly ArgTypes
     readonly step: SystemArgs<StepArgTypes>['step'];
     readonly before: ReadonlySet<System | string>;
     readonly after: ReadonlySet<System | string>;
+    readonly event: Symbol;
     readonly query: Query<StepArgTypes>;
 
-    constructor({ name, args, step, before, after }: SystemArgs<StepArgTypes>) {
+    constructor({ name, args, step, before, after, event }: SystemArgs<StepArgTypes>) {
         this.name = name;
         this.args = args;
         this.step = step;
         this.before = new Set([...before ?? []]);
         this.after = new Set([...after ?? []]);
+        this.event = event ?? StepEvent;
         this.query = new Query(args);
     }
 


### PR DESCRIPTION
Events cause systems to run on sets of entities. Systems define what event they respond to. The default event is the `Step` event, which is triggered on all entities whenever `world.step()` is called. 

The delete event runs whenever an entity is deleted, and allows for cleaning up mutable components like PIXI sprites.