### PR TITLE
Remove immer from many parts of the engine

### DIFF
--- a/nova/src/display/BUILD.bazel
+++ b/nova/src/display/BUILD.bazel
@@ -17,5 +17,6 @@ ts_library(
         "@npm//pixi.js",
         "@npm//uuid",
         "@npm//@types/uuid",
+        "@npm//immer",
     ]
 )

--- a/nova/src/display/display_plugin.ts
+++ b/nova/src/display/display_plugin.ts
@@ -1,5 +1,4 @@
 import { Animation } from "novadatainterface/Animation";
-import { GameDataInterface } from "novadatainterface/GameDataInterface";
 import { Component } from "nova_ecs/component";
 import { DeleteEvent } from "nova_ecs/events";
 import { Plugin } from "nova_ecs/plugin";
@@ -7,6 +6,7 @@ import { MovementStateComponent } from "nova_ecs/plugins/movement_plugin";
 import { Provide, ProvideAsync } from "nova_ecs/provider";
 import { Resource } from "nova_ecs/resource";
 import { System } from "nova_ecs/system";
+import { currentIfDraft } from "nova_ecs/utils";
 import { GameDataResource } from "../nova_plugin/game_data_resource";
 import { ShipDataProvider } from "../nova_plugin/ship_component";
 import { AnimationGraphic } from "./animation_graphic";
@@ -33,10 +33,9 @@ const AnimationGraphicProvider = ProvideAsync({
     args: [ShipAnimationComponentProvider, Stage, GameDataResource] as const,
     factory: async (animation, stage, gameData) => {
         const graphic = new AnimationGraphic({
-            gameData: gameData as GameDataInterface,
-            animation: animation as Animation,
+            gameData: currentIfDraft(gameData)!,
+            animation: currentIfDraft(animation)!,
         });
-
         await graphic.buildPromise;
         stage.addChild(graphic.container);
         return graphic;
@@ -48,7 +47,7 @@ const AnimationGraphicCleanup = new System({
     events: [DeleteEvent],
     args: [AnimationGraphicComponent, Stage] as const,
     step: (graphic, stage) => {
-        stage.removeChild(graphic.container as PIXI.Container);
+        stage.removeChild(graphic.container);
     }
 });
 
@@ -59,7 +58,7 @@ const ShipDrawSystem = new System({
     step: (movementState, graphic) => {
         graphic.container.position.x = movementState.position.x;
         graphic.container.position.y = movementState.position.y;
-        graphic.container.rotation = movementState.rotation.angle;
+        graphic.rotation = movementState.rotation.angle;
     }
 });
 

--- a/nova/src/nova_plugin/server_plugin.ts
+++ b/nova/src/nova_plugin/server_plugin.ts
@@ -1,15 +1,15 @@
-import { SingletonComponent } from "nova_ecs/world";
 import { Entities, UUID } from "nova_ecs/arg_types";
-import { AsyncSystem } from "nova_ecs/async_system";
 import { Plugin } from "nova_ecs/plugin";
 import { MultiplayerData, PeersChanged } from "nova_ecs/plugins/multiplayer_plugin";
 import { Query } from "nova_ecs/query";
+import { System } from "nova_ecs/system";
+import { SingletonComponent } from "nova_ecs/world";
 import { v4 } from "uuid";
 import { GameDataResource } from "./game_data_resource";
 import { makeShip } from "./make_ship";
 
 
-export const manageClientsSystem = new AsyncSystem({
+export const manageClientsSystem = new System({
     name: 'ManageClients',
     events: [PeersChanged], // TODO: Fix async systems that use events.
     args: [GameDataResource, PeersChanged, new Query([MultiplayerData, UUID] as const),

--- a/nova/src/nova_plugin/server_plugin.ts
+++ b/nova/src/nova_plugin/server_plugin.ts
@@ -1,46 +1,20 @@
-import { isDraft, original } from "immer";
-import { Component } from "nova_ecs/component";
-import { System } from "nova_ecs/system";
+import { SingletonComponent } from "nova_ecs/world";
 import { Entities, UUID } from "nova_ecs/arg_types";
 import { AsyncSystem } from "nova_ecs/async_system";
 import { Plugin } from "nova_ecs/plugin";
-import { Comms, MultiplayerData } from "nova_ecs/plugins/multiplayer_plugin";
+import { MultiplayerData, PeersChanged } from "nova_ecs/plugins/multiplayer_plugin";
 import { Query } from "nova_ecs/query";
 import { v4 } from "uuid";
-import { setDifference } from "../common/SetUtils";
 import { GameDataResource } from "./game_data_resource";
 import { makeShip } from "./make_ship";
 
 
-export const PeersChanged = new Component<{
-    newPeers: Set<string>,
-    removedPeers: Set<string>,
-}>({ name: 'PeersChanged' });
-
-// This computation can't be done in AsyncSystem because
-// arguments to it are frozen, so 'original' doesn't work.
-export const peersChangedSystem = new System({
-    name: 'PeersChanged',
-    args: [Comms, PeersChanged] as const,
-    step: (comms, peersChanged) => {
-        const originalPeers = original(comms)?.peers ?? comms.peers;
-        peersChanged.newPeers = setDifference(comms.peers, originalPeers);
-        peersChanged.removedPeers = setDifference(originalPeers, comms.peers);
-    },
-    after: ['ApplyChanges'],
-})
-
 export const manageClientsSystem = new AsyncSystem({
     name: 'ManageClients',
-    args: [Comms, PeersChanged, GameDataResource,
-        new Query([MultiplayerData, UUID] as const), Entities] as const,
-    step: async (comms, peersChanged, gameData, multiplayerEntities, entities) => {
-        if (!isDraft(comms)) {
-            // Then there's no way we have new peers since
-            // peers can only be added by drafting
-            return;
-        }
-
+    events: [PeersChanged], // TODO: Fix async systems that use events.
+    args: [GameDataResource, PeersChanged, new Query([MultiplayerData, UUID] as const),
+        Entities, SingletonComponent] as const,
+    step: async (gameData, peersChanged, multiplayerEntities, entities) => {
         // Remove entities of peers who have disconnected
         // TODO: Save them for when they reconnect.
         if (peersChanged.removedPeers.size > 0) {
@@ -52,7 +26,7 @@ export const manageClientsSystem = new AsyncSystem({
         }
 
         // TODO: Give them back the entitiy they disconnected with.
-        for (const newPeer of peersChanged.newPeers) {
+        for (const newPeer of peersChanged.addedPeers) {
             console.log(`Adding ship for peer ${newPeer}`);
             const ids = await gameData.ids;
             const randomShip = ids.Ship[Math.floor(Math.random() * ids.Ship.length)];
@@ -65,8 +39,6 @@ export const manageClientsSystem = new AsyncSystem({
             console.log(`Ship added for peer ${newPeer}`);
         }
     },
-    after: ['ApplyChanges', peersChangedSystem],
-    before: ['SendChanges'],
 });
 
 
@@ -74,10 +46,5 @@ export const ServerPlugin: Plugin = {
     name: 'Server',
     build(world) {
         world.addSystem(manageClientsSystem);
-        world.addSystem(peersChangedSystem);
-        world.singletonEntity.components.set(PeersChanged, {
-            newPeers: new Set<string>(),
-            removedPeers: new Set<string>(),
-        });
     }
 }

--- a/nova_ecs/arg_types.ts
+++ b/nova_ecs/arg_types.ts
@@ -47,7 +47,8 @@ export type ArgTypes = Component<any, any, any, any>
 type AllowUndefined<T> = T extends undefined ? T : never;
 
 export type ArgData<T> =
-    Draft<ComponentData<T> | ResourceData<T>>
+    ComponentData<T>
+    | ResourceData<T>
     | QueryResults<T>
     | EventData<T>
     | EntitiesObject<T>

--- a/nova_ecs/arg_types.ts
+++ b/nova_ecs/arg_types.ts
@@ -1,5 +1,4 @@
 import { Either } from "fp-ts/lib/Either";
-import { Draft } from "immer";
 import { Component, ComponentData, UnknownComponent } from "./component";
 import { Entity } from "./entity";
 import { EntityMap } from "./entity_map";

--- a/nova_ecs/component_map.ts
+++ b/nova_ecs/component_map.ts
@@ -1,8 +1,4 @@
-import { Draft } from "immer";
 import { Component, UnknownComponent } from "./component";
-import { MutableImmutableMapHandle } from "./mutable_immutable_map_handle";
-import { currentIfDraft } from "./utils";
-import { CallWithDraft, State } from "./world";
 
 export interface ReadonlyComponentMap extends ReadonlyMap<UnknownComponent, unknown> {
     get<Data>(component: Component<Data, any, any, any>): Data | undefined;
@@ -12,37 +8,4 @@ export interface ComponentMap extends Map<UnknownComponent, unknown> {
     get<Data>(component: Component<Data, any, any, any>): Data | undefined;
     set<Data>(component: Component<Data, any, any, any>, data: Data): this;
     delete(component: Component<any, any, any, any>): boolean;
-}
-
-export class ComponentMapHandle
-    extends MutableImmutableMapHandle<UnknownComponent, unknown>
-    implements ComponentMap {
-
-    constructor(private entityUuid: string, callWithDraft: CallWithDraft<State>,
-        private addComponent: (component: Component<any, any, any, any>) => void) {
-        super((callback) => callWithDraft(
-            draft => callback(this.getEntityComponents(draft))),
-            currentIfDraft);
-    }
-
-    private getEntityComponents(draft: Draft<State>) {
-        const entity = draft.entities.get(this.entityUuid);
-        if (!entity) {
-            throw new Error(`Entity '${this.entityUuid}' not in the world`);
-        }
-        return entity.components;
-    }
-
-    get<Data>(component: Component<Data, any, any, any>): Data | undefined {
-        return super.get(component as UnknownComponent) as Data;
-    };
-
-    set<Data>(component: Component<Data, any, any, any>, data: Data): this {
-        this.addComponent(component);
-        return super.set(component as UnknownComponent, data);
-    };
-
-    delete(component: Component<any, any, any, any>): boolean {
-        return super.delete(component as UnknownComponent);
-    };
 }

--- a/nova_ecs/demo/demo.ts
+++ b/nova_ecs/demo/demo.ts
@@ -143,7 +143,10 @@ const AddSquares = new System({
                 y: Math.sin(angle) * addSquares.radius + window.innerHeight / 2,
             }
 
-            for (let i = 0; i < addSquares.count; i++) {
+            const life = 20_000;
+            const count = (addSquares.max / life) * Math.max(addSquares.period, 16);
+
+            for (let i = 0; i < count; i++) {
                 let color = 0;
                 const gamma = 0.6 / (1.1 + Math.sin(time.time / 2000));
                 for (let j = 0; j < 3; j++) {
@@ -162,7 +165,7 @@ const AddSquares = new System({
                             y: (Math.random() - 0.5) * 60,
                         },
                         createTime: time.time,
-                        life: 20_000
+                        life,
                     }).build());
             }
         }
@@ -243,7 +246,10 @@ const Demo: Plugin = {
 }
 
 function main() {
-    const app = new PIXI.Application();
+    const app = new PIXI.Application({
+        autoDensity: true
+    });
+
     document.body.appendChild(app.view);
     const stats = new Stats();
     document.body.appendChild(stats.dom);

--- a/nova_ecs/entity_map.ts
+++ b/nova_ecs/entity_map.ts
@@ -1,94 +1,16 @@
-import { Component } from "./component";
-import { ComponentMapHandle } from "./component_map";
+import { ComponentMap } from "./component_map";
 import { Entity } from "./entity";
-import { CallWithDraft, State } from "./world";
+import { EventMap } from "./event_map";
+
 
 export interface EntityMap extends Map<string, Entity> { }
 
-export class EntityMapHandle implements EntityMap {
-    constructor(private callWithDraft: CallWithDraft<State>,
-        // addComponnet adds a component as something the world knows about.
-        // Doesn't add it to an entity.
-        private addComponent: (component: Component<any, any, any, any>) => void) { }
 
-    clear(): void {
-        this.callWithDraft(draft => {
-            draft.entities.clear();
-        });
-    }
-
-    delete(uuid: string): boolean {
-        if (uuid === 'singleton') {
+export class EntityMapWrapped extends EventMap<string, Entity> {
+    delete(key: string) {
+        if (key === 'singleton') {
             throw new Error('Can not delete the singleton entity');
         }
-        return this.callWithDraft(draft => draft.entities.delete(uuid));
+        return super.delete(key);
     }
-
-    forEach(callbackfn: (value: Entity, key: string,
-        map: Map<string, Entity>) => void, thisArg?: any): void {
-        for (const [key, val] of this) {
-            callbackfn.call(thisArg, val, key, this);
-        }
-    }
-
-    get(uuid: string): Entity | undefined {
-        return this.callWithDraft(draft => {
-            const entity = draft.entities.get(uuid);
-            if (!entity) {
-                return undefined;
-            }
-            return {
-                components: new ComponentMapHandle(uuid,
-                    this.callWithDraft, this.addComponent),
-                multiplayer: entity.multiplayer,
-                name: entity.name,
-            }
-        });
-    }
-
-    has(key: string): boolean {
-        return this.callWithDraft(draft =>
-            draft.entities.has(key)
-        );
-    }
-
-    set(uuid: string, entity: Entity): this {
-        for (const [component] of entity.components) {
-            this.addComponent(component);
-        }
-
-        this.callWithDraft(draft => {
-            draft.entities.set(uuid, entity);
-        });
-
-        return this;
-    }
-
-    get size(): number {
-        return this.callWithDraft(draft => draft.entities.size);
-    }
-
-    [Symbol.iterator](): IterableIterator<[string, Entity]> {
-        return this.entries();
-    }
-
-    *entries(): IterableIterator<[string, Entity]> {
-        for (const key of this.keys()) {
-            yield [key, this.get(key)!];
-        }
-    }
-
-    *keys(): IterableIterator<string> {
-        yield* this.callWithDraft(draft => {
-            return [...draft.entities.keys()];
-        });
-    }
-
-    *values(): IterableIterator<Entity> {
-        for (const key of this.keys()) {
-            yield this.get(key)!;
-        }
-    }
-
-    [Symbol.toStringTag]: string;
 }

--- a/nova_ecs/plugins/movement_plugin.ts
+++ b/nova_ecs/plugins/movement_plugin.ts
@@ -55,11 +55,8 @@ export const MovementStateComponent = new Component({
     getDelta(a, b): MovementState | undefined {
         // Omit position.
         // Send everything if a delta is detected.
-        const same = a.velocity.x === b.velocity.x &&
-            a.velocity.y === b.velocity.y &&
-            a.rotation.angle === b.rotation.angle &&
-            a.accelerating === b.accelerating &&
-            a.turning === b.turning;
+        const same = a.turning === b.turning &&
+            a.accelerating === b.accelerating;
 
         if (same) {
             return;

--- a/nova_ecs/plugins/multiplayer_plugin_test.ts
+++ b/nova_ecs/plugins/multiplayer_plugin_test.ts
@@ -1,4 +1,5 @@
 import { isLeft } from 'fp-ts/lib/Either';
+import { isDraft } from 'immer';
 import * as t from 'io-ts';
 import 'jasmine';
 import { Entities, UUID } from '../arg_types';
@@ -89,8 +90,7 @@ describe('Multiplayer Plugin', () => {
             name: 'BarSystem',
             args: [BarComponent] as const,
             step: () => { },
-            before: ['SendChanges'],
-            after: ['ApplyChanges'],
+            after: ['Multiplayer'],
         });
         world1.addSystem(barSystem);
 
@@ -100,8 +100,7 @@ describe('Multiplayer Plugin', () => {
             step: (bar, uuid) => {
                 reports.push([bar.y, uuid]);
             },
-            before: ['SendChanges'],
-            after: ['ApplyChanges'],
+            after: ['Multiplayer'],
         });
         world2.addSystem(reportSystem);
 
@@ -128,16 +127,14 @@ describe('Multiplayer Plugin', () => {
             step: (bar) => {
                 bar.y = bar.y + ' stepped';
             },
-            after: ['ApplyChanges'],
-            before: ['SendChanges'],
+            after: ['Multiplayer'],
         });
         world1.addSystem(barSystem);
 
         const reportSystem = new System({
             name: 'ReportSystem',
             args: [BarComponent] as const,
-            after: ['ApplyChanges'],
-            before: ['SendChanges'],
+            after: ['Multiplayer'],
             step: (bar) => {
                 reports.push(bar.y);
             }
@@ -162,9 +159,9 @@ describe('Multiplayer Plugin', () => {
         world2.step();
 
         expect(reports).toEqual([
+            'a test component',
             'a test component stepped',
             'a test component stepped stepped',
-            'a test component stepped stepped stepped',
         ]);
     });
 
@@ -190,8 +187,7 @@ describe('Multiplayer Plugin', () => {
                     entities.delete(uuid);
                 }
             },
-            after: ['ApplyChanges'],
-            before: ['SendChanges'],
+            before: ['Multiplayer'],
         });
 
         world1.addSystem(removeBarSystem);
@@ -207,6 +203,9 @@ describe('Multiplayer Plugin', () => {
         world1.step();
         world2.step();
 
+        world1.step();
+        world2.step();
+
         expect(world2.entities.get(testUuid)!.components.get(BarComponent))
             .toEqual(world1.entities.get(testUuid)!.components.get(BarComponent))
 
@@ -215,5 +214,36 @@ describe('Multiplayer Plugin', () => {
         world2.step();
 
         expect(world2.entities.get(testUuid)).toBeUndefined();
+    });
+
+
+    it('drafts components of entities it owns', () => {
+        const testUuid = 'test entity uuid';
+        world1.entities.set(testUuid, new EntityBuilder()
+            .addComponent(MultiplayerData, {
+                owner: 'world1 uuid',
+            }).addComponent(BarComponent, {
+                y: 'a test component',
+            }).build());
+
+        world1.step();
+
+        const bar = world1.entities.get(testUuid)?.components.get(BarComponent);
+        expect(isDraft(bar)).toBeTrue();
+    });
+
+    it('does not draft components of entities it does not own', () => {
+        const testUuid = 'test entity uuid';
+        world1.entities.set(testUuid, new EntityBuilder()
+            .addComponent(MultiplayerData, {
+                owner: 'not me',
+            }).addComponent(BarComponent, {
+                y: 'a test component',
+            }).build());
+
+        world1.step();
+
+        const bar = world1.entities.get(testUuid)?.components.get(BarComponent);
+        expect(isDraft(bar)).toBeFalse();
     });
 });

--- a/nova_ecs/plugins/multiplayer_plugin_test.ts
+++ b/nova_ecs/plugins/multiplayer_plugin_test.ts
@@ -20,6 +20,8 @@ const BarComponent = new Component({
     applyDelta: applyObjectDelta
 });
 
+const NonMultiplayer = new Component<{ z: string }>({ name: 'NonMultiplayer' });
+
 class MockCommunicator implements Communicator {
     incomingMessages: Message[] = [];
     constructor(public uuid: string | undefined,
@@ -245,5 +247,25 @@ describe('Multiplayer Plugin', () => {
 
         const bar = world1.entities.get(testUuid)?.components.get(BarComponent);
         expect(isDraft(bar)).toBeFalse();
+    });
+
+    it('does not draft non-multiplayer components', () => {
+        const testUuid = 'test entity uuid';
+        world1.entities.set(testUuid, new EntityBuilder()
+            .addComponent(MultiplayerData, {
+                owner: 'world1 uuid',
+            }).addComponent(BarComponent, {
+                y: 'a test component',
+            }).addComponent(NonMultiplayer, {
+                z: 'not multiplayer'
+            }).build());
+
+        world1.step();
+
+        const bar = world1.entities.get(testUuid)?.components.get(BarComponent);
+        expect(isDraft(bar)).toBeTrue();
+
+        const nonMultiplaer = world1.entities.get(testUuid)?.components.get(NonMultiplayer);
+        expect(isDraft(nonMultiplaer)).toBeFalse();
     });
 });

--- a/nova_ecs/provider.ts
+++ b/nova_ecs/provider.ts
@@ -1,7 +1,6 @@
-import { Either, left, right } from "fp-ts/lib/Either";
-import { applyPatches, createDraft, finishDraft, Patch } from "immer";
-import { ArgData, ArgsToData, ArgTypes, GetArg, GetEntity, UUID } from "./arg_types";
-import { getCurrentArgs } from "./async_system";
+import { left, right } from "fp-ts/lib/Either";
+import { applyPatches, createDraft, enableMapSet, enablePatches, finishDraft, Patch, setAutoFreeze } from "immer";
+import { ArgData, ArgsToData, ArgTypes, GetEntity, UUID } from "./arg_types";
 import { Component, ComponentData, UnknownComponent } from "./component";
 import { Modifier } from "./modifier";
 import { Optional } from "./optional";
@@ -49,6 +48,10 @@ export function Provide<Provided extends Component<any, any, any, any>, Args ext
     });
 }
 
+enablePatches();
+enableMapSet();
+setAutoFreeze(false);
+
 // TODO: Refactor this with AsyncSystem?
 export function ProvideAsync<Provided extends Component<any, any, any, any>, Args extends readonly ArgTypes[]>({ provided, factory, args }: {
     provided: Provided,
@@ -86,8 +89,7 @@ export function ProvideAsync<Provided extends Component<any, any, any, any>, Arg
                 return left(undefined);
             } else {
                 // TODO: Refactor with Async system
-                const currentArgs = getCurrentArgs(args, argData);
-                const draftArgs = createDraft(currentArgs);
+                const draftArgs = createDraft(argData);
                 const newData = factory(...draftArgs as typeof argData);
                 const providerMapEntry: ProviderMapEntry = {
                     complete: false,

--- a/nova_ecs/utils.ts
+++ b/nova_ecs/utils.ts
@@ -1,15 +1,15 @@
-import { current, Draft, Immutable, isDraft } from "immer";
+import { current, Draft, isDraft } from "immer";
 import { UnknownComponent } from "./component";
 
 export interface WithComponents {
     components: ReadonlyMap<UnknownComponent, unknown>;
 }
 
-export function currentIfDraft<T>(val: T | Draft<T>): Immutable<T> {
+export function currentIfDraft<T>(val: T | Draft<T>): T {
     if (isDraft(val)) {
-        return current(val) as Immutable<T>;
+        return current(val) as T;
     }
-    return val as Immutable<T>;
+    return val as T;
 }
 
 /**

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -85,6 +85,7 @@ export class World {
         this.addPlugin(ProvideAsyncPlugin);
         this.entities.set('singleton', new EntityBuilder()
             .addComponent(SingletonComponent, undefined)
+            .setName('singleton')
             .build());
 
         // Get the handle for the singleton entity.
@@ -97,9 +98,7 @@ export class World {
 
         this.state.resources.events.set.subscribe(added => {
             this.addResource(added[0]);
-        })
-
-
+        });
     }
 
     emit<Data>(event: EcsEvent<Data, any>, data: Data, entities?: Set<string>) {

--- a/nova_ecs/world.ts
+++ b/nova_ecs/world.ts
@@ -2,7 +2,7 @@ import { Either, isLeft, isRight, left, Right, right } from "fp-ts/lib/Either";
 import { ArgData, ArgsToData, ArgTypes, Components, Emit, EmitFunction, Entities, GetArg, GetEntity, QueryResults, UUID } from "./arg_types";
 import { AsyncSystemPlugin } from "./async_system";
 import { Component, UnknownComponent } from "./component";
-import { Entity } from "./entity";
+import { Entity, EntityBuilder } from "./entity";
 import { EntityMapWrapped } from "./entity_map";
 import { DeleteEvent, EcsEvent, StepEvent, UnknownEvent } from "./events";
 import { Modifier, UnknownModifier } from "./modifier";
@@ -52,6 +52,8 @@ import { topologicalSort } from './utils';
 // Idea: Load async stuff by adding components to the entity as the data becomes
 // available?
 
+export const SingletonComponent = new Component<undefined>({ name: 'SingletonComponent' });
+
 interface EcsEventWithEntities<Data> {
     event: EcsEvent<Data, any>;
     data: Data;
@@ -81,11 +83,10 @@ export class World {
     constructor(private name?: string) {
         this.addPlugin(AsyncSystemPlugin);
         this.addPlugin(ProvideAsyncPlugin);
-        this.entities.set('singleton', {
-            components: new Map(),
-            multiplayer: false,
-            name: 'singleton'
-        });
+        this.entities.set('singleton', new EntityBuilder()
+            .addComponent(SingletonComponent, undefined)
+            .build());
+
         // Get the handle for the singleton entity.
         this.singletonEntity = this.entities.get('singleton')!;
 

--- a/nova_ecs/world_test.ts
+++ b/nova_ecs/world_test.ts
@@ -1,4 +1,3 @@
-import { original } from 'immer';
 import * as t from 'io-ts';
 import 'jasmine';
 import { v4 } from 'uuid';
@@ -299,38 +298,6 @@ describe('world', () => {
         expect(stepData).toEqual(['first', 'second', 'third', 'fourth']);
     });
 
-    it('allows getting the original state for a given step', () => {
-        const stepData: string[] = [];
-
-        const firstSystem = new System({
-            name: 'FirstSystem',
-            args: [BAR_COMPONENT] as const,
-            step: (bar) => {
-                bar.y = 'first';
-            },
-        });
-        const secondSystem = new System({
-            name: 'SecondSystem',
-            args: [BAR_COMPONENT] as const,
-            step: (bar) => {
-                stepData.push(bar.y);
-                const orig = original(bar);
-                stepData.push(orig?.y ?? 'no original found');
-            },
-            after: new Set([firstSystem]),
-        });
-
-        world.entities.set(v4(), new EntityBuilder()
-            .addComponent(BAR_COMPONENT, { y: 'original value' }));
-
-        world.addSystem(firstSystem)
-            .addSystem(secondSystem);
-
-        world.step();
-
-        expect(stepData).toEqual(['first', 'original value']);
-    });
-
     it('supports optional arguments in systems', () => {
         const stepData: [number, string | undefined][] = [];
 
@@ -512,7 +479,7 @@ describe('world', () => {
             .toThrowError('Can not delete the singleton entity');
     });
 
-    it('does not allow systems to have the same name', () => {
+    xit('does not allow systems to have the same name', () => {
         const system1 = new System({
             name: 'TestSystem',
             args: [FOO_COMPONENT],
@@ -531,7 +498,7 @@ describe('world', () => {
             .toThrowError(`A system with name ${system2.name} already exists`);
     });
 
-    it('does not allow resources to have the same name', () => {
+    xit('does not allow resources to have the same name', () => {
         const resource1 = new Resource({
             name: 'TestResource',
             type: t.string,
@@ -551,7 +518,7 @@ describe('world', () => {
             .toThrowError(`A resource with name ${resource2.name} already exists`);
     });
 
-    it('does not allow components to have the same name', () => {
+    xit('does not allow components to have the same name', () => {
         const component1 = new Component({
             name: 'TestComponent',
             type: t.string,
@@ -576,7 +543,7 @@ describe('world', () => {
             .toThrowError(`A component with name ${component1.name} already exists`);
     });
 
-    it('catches component name conflicts', () => {
+    xit('catches component name conflicts', () => {
         const component1 = new Component<string>({ name: 'TestComponent' });
         const component2 = new Component<string>({ name: 'TestComponent' });
 
@@ -586,7 +553,7 @@ describe('world', () => {
             .toThrowError(`A component with name ${component1.name} already exists`);
     });
 
-    it('catches component name conflicts when adding them to entities', () => {
+    xit('catches component name conflicts when adding them to entities', () => {
         const component1 = new Component<string>({ name: 'TestComponent' });
         const component2 = new Component<string>({ name: 'TestComponent' });
 
@@ -798,27 +765,6 @@ describe('world', () => {
             .toEqual('changed bar');
     });
 
-    it('supports immutable resources', () => {
-        const pushed: string[] = [];
-        const changeResourceSystem = new System({
-            name: 'ChangeResourceSystem',
-            args: [BAZ_RESOURCE],
-            step: (baz) => {
-                baz.z.push('hello');
-                pushed.push('hello');
-            }
-        });
-
-        const bazVal: ResourceData<typeof BAZ_RESOURCE> = { z: [] };
-        world.resources.set(BAZ_RESOURCE, bazVal);
-        world.addSystem(changeResourceSystem);
-
-        world.step();
-
-        expect(bazVal).toEqual({ z: [] });
-        expect(pushed).toEqual(['hello']);
-    });
-
     it('supports mutable resources', () => {
         const MutableResource = new Resource<MutableObject>({
             name: 'MutableResource',
@@ -839,30 +785,6 @@ describe('world', () => {
         world.step();
 
         expect(resourceVal).toEqual(new MutableObject('changed'));
-    });
-
-    it('supports immutable components', () => {
-        let changed = 'unchanged';
-        const changeComponentSystem = new System({
-            name: 'ChangeComponentSystem',
-            args: [BAR_COMPONENT],
-            step: (bar) => {
-                bar.y = 'changed';
-                changed = 'changed';
-            }
-        });
-
-        const barVal: ComponentData<typeof BAR_COMPONENT> = { y: 'unchanged' };
-        world.entities.set('example uuid', new EntityBuilder()
-            .addComponent(BAR_COMPONENT, barVal)
-            .build());
-
-        world.addSystem(changeComponentSystem);
-
-        world.step();
-
-        expect(barVal).toEqual({ y: 'unchanged' });
-        expect(changed).toEqual('changed');
     });
 
     it('supports mutable components', () => {

--- a/nova_ecs/world_test.ts
+++ b/nova_ecs/world_test.ts
@@ -479,7 +479,7 @@ describe('world', () => {
             .toThrowError('Can not delete the singleton entity');
     });
 
-    xit('does not allow systems to have the same name', () => {
+    it('does not allow systems to have the same name', () => {
         const system1 = new System({
             name: 'TestSystem',
             args: [FOO_COMPONENT],
@@ -498,7 +498,7 @@ describe('world', () => {
             .toThrowError(`A system with name ${system2.name} already exists`);
     });
 
-    xit('does not allow resources to have the same name', () => {
+    it('does not allow resources to have the same name', () => {
         const resource1 = new Resource({
             name: 'TestResource',
             type: t.string,
@@ -518,20 +518,9 @@ describe('world', () => {
             .toThrowError(`A resource with name ${resource2.name} already exists`);
     });
 
-    xit('does not allow components to have the same name', () => {
-        const component1 = new Component({
-            name: 'TestComponent',
-            type: t.string,
-            getDelta: () => { },
-            applyDelta: () => { },
-        });
-
-        const component2 = new Component({
-            name: 'TestComponent',
-            type: t.string,
-            getDelta: () => { },
-            applyDelta: () => { },
-        });
+    it('catches component name conflicts when required by systems', () => {
+        const component1 = new Component<string>({ name: 'TestComponent' });
+        const component2 = new Component<string>({ name: 'TestComponent' });
 
         const testSystem = new System({
             name: 'TestSystem',
@@ -543,7 +532,7 @@ describe('world', () => {
             .toThrowError(`A component with name ${component1.name} already exists`);
     });
 
-    xit('catches component name conflicts', () => {
+    it('catches component name conflicts', () => {
         const component1 = new Component<string>({ name: 'TestComponent' });
         const component2 = new Component<string>({ name: 'TestComponent' });
 


### PR DESCRIPTION
The only parts of the engine that really need to use immer are the multiplayer plugin and async system / async provider.