### PR TITLE
Allow reading from the bazel remote cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -72,6 +72,18 @@ build --nolegacy_external_runfiles
 build --incompatible_strict_action_env
 run --incompatible_strict_action_env
 
+# Make TypeScript and Angular compilation fast, by keeping a few copies of the
+# compiler running as daemons, and cache SourceFile AST's to reduce parse time.
+build --strategy=TypeScriptCompile=worker
+
+# Remote build caching
+build:remote_cache --remote_http_cache=https://storage.googleapis.com/bazel-remote-cache-novajs --remote_upload_local_results=false
+build:ci --remote_http_cache=https://storage.googleapis.com/bazel-remote-cache-novajs --remote_upload_local_results=true
+
+# Use https://github.com/Evertz/bru
+common:bru --bes_backend=grpc://localhost:5000
+common:bru --bes_results_url=http://localhost:8080/invocation
+
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members
 # This needs to be last statement in this
@@ -80,12 +92,3 @@ run --incompatible_strict_action_env
 # (Note that we use .bazelrc.user so the file appears next to .bazelrc in directory listing,
 # rather than user.bazelrc as suggested in the Bazel docs)
 try-import %workspace%/.bazelrc.user
-
-# Make TypeScript and Angular compilation fast, by keeping a few copies of the
-# compiler running as daemons, and cache SourceFile AST's to reduce parse time.
-build --strategy=TypeScriptCompile=worker
-
-
-# Use https://github.com/Evertz/bru
-common:bru --bes_backend=grpc://localhost:5000
-common:bru --bes_results_url=http://localhost:8080/invocation

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: gcr.io/cloud-builders/bazel
     id: unittest
-    args: ['test', '--google_default_credentials', '--remote_http_cache=https://storage.googleapis.com/bazel-remote-cache-novajs', '...']
+    args: ['test', '--config=ci', '--google_default_credentials', '...']
 
 timeout: 900s
 options:

--- a/deploy_demo.yaml
+++ b/deploy_demo.yaml
@@ -2,7 +2,7 @@ steps:
   # Test novajs
   - name: gcr.io/cloud-builders/bazel
     id: unittest
-    args: ['test', '--google_default_credentials', '--remote_http_cache=https://storage.googleapis.com/bazel-remote-cache-novajs', '...']
+    args: ['test', '--config=ci', '--google_default_credentials', '...']
 
   # Copy nova files into the repository
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -21,7 +21,7 @@ steps:
   # Publish the image
   - name: gcr.io/cloud-builders/bazel
     id: push_container
-    args: ['run', '--google_default_credentials', '--remote_http_cache=https://storage.googleapis.com/bazel-remote-cache-novajs', '//nova:push_nova_image']
+    args: ['run', '--config=ci', '--google_default_credentials', '//nova:push_nova_image']
     waitFor: ['copy-novafiles', 'copy-plugins']
 
   # Deploy to cloud run


### PR DESCRIPTION
This can be enabled by default by adding `--config=remote_cache` to `.bazelrc.user`, but is disabled by default. Only Cloud CI can push to the remote cache.