### PR TITLE
Remove 'multiplayer' property from entities

### DIFF
--- a/nova/src/nova_plugin/make_ship.ts
+++ b/nova/src/nova_plugin/make_ship.ts
@@ -2,7 +2,7 @@ import { ShipData } from "novadatainterface/ShipData";
 import { Angle } from "nova_ecs/datatypes/angle";
 import { Position } from "nova_ecs/datatypes/position";
 import { Vector } from "nova_ecs/datatypes/vector";
-import { Entity, EntityBuilder } from "nova_ecs/entity";
+import { Entity } from "nova_ecs/entity";
 import { MovementPhysicsComponent, MovementStateComponent, MovementType } from "nova_ecs/plugins/movement_plugin";
 import { ShipComponent } from "./ship_component";
 
@@ -10,7 +10,6 @@ import { ShipComponent } from "./ship_component";
 export function makeShip(shipData: ShipData): Entity {
     const ship: Entity = {
         components: new Map(),
-        multiplayer: true,
         name: shipData.name,
     }
     ship.components.set(ShipComponent, {

--- a/nova_ecs/entity.ts
+++ b/nova_ecs/entity.ts
@@ -6,26 +6,25 @@ export type ComponentTypes = Set<UnknownComponent>;
 
 export interface Entity {
     components: ComponentMap,
-    multiplayer: boolean;
     name?: string;
 }
 
+/**
+ * A convenience class for creating Entities
+ */
 export class EntityBuilder {
     [immerable] = true;
     components: ComponentMap;
-    multiplayer: boolean;
     name?: string;
 
     constructor(entity?: Entity) {
         this.components = new Map([...entity?.components ?? []]) as ComponentMap;
-        this.multiplayer = entity?.multiplayer ?? false;
         this.name = entity?.name;
     }
 
     build(): Entity {
         return {
             components: this.components,
-            multiplayer: this.multiplayer,
             name: this.name,
         };
     }

--- a/nova_ecs/plugins/serializer_plugin.ts
+++ b/nova_ecs/plugins/serializer_plugin.ts
@@ -47,7 +47,6 @@ export class Serializer {
 
             const entity: Entity = {
                 components: new Map(),
-                multiplayer: false,
                 name: state.name,
             };
 


### PR DESCRIPTION
It's not needed anymore. An entity is known to be a multiplayer entity if it has the `MultiplayerData` component.