### PR TITLE
Implement starfield using sprites and rbush

### DIFF
--- a/nova/src/display/BUILD.bazel
+++ b/nova/src/display/BUILD.bazel
@@ -43,6 +43,8 @@ ts_library(
         "@npm//rbush",
         "@npm//@types/rbush",
         "@npm//pixi-particles",
+        "@npm//seedrandom",
+        "@npm//@types/seedrandom",
     ]
 )
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@types/pngjs": "^6.0.0",
         "@types/rbush": "^3.0.0",
         "@types/sat": "^0.0.31",
+        "@types/seedrandom": "^3.0.0",
         "@types/stats.js": "^0.17.0",
         "@types/supports-color": "^8.1.0",
         "@types/url-join": "^4.0.0",
@@ -47,6 +48,7 @@
         "rbush": "^3.0.1",
         "requirejs": "^2.3.6",
         "sat": "^0.9.0",
+        "seedrandom": "^3.0.5",
         "stats.js": "^0.17.0",
         "typescript": "~4.3.2",
         "url-join": "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,6 +580,11 @@
   resolved "https://registry.yarnpkg.com/@types/sat/-/sat-0.0.31.tgz#6f0bb95f333649fb8d77ae8909e5ed104fe477bb"
   integrity sha512-P4SVw79XheP1p92useDVpLYYOUQ6lpw2L7IdQz4dD23DZ8DiC1STgPOh72hjR5IZJBPQbzlICAbmjCKbwyYuxg==
 
+"@types/seedrandom@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.0.tgz#13f4d71aa58cf6068a2e75261a4580fb71dc84e6"
+  integrity sha512-Jr03BtXs7v6M/wtTum2VOMLBq7R8zpjdZLynhA/IOJq83czXrnVo8iSUI05gcq8Ecq0Swt+nuoK3y2ji/TWyMA==
+
 "@types/serve-static@*":
   version "1.13.9"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.9.tgz#aacf28a85a05ee29a11fb7c3ead935ac56f33e4e"
@@ -1840,6 +1845,11 @@ sat@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/sat/-/sat-0.9.0.tgz#02091260513c8f2482da7db9377ddfeca80f5982"
   integrity sha512-mxdv5RZJO4tdMnUURGU3gAMcnDUEwcNJwE+lPO0/V+rBeDvFLH3wEZEOR0fH7cTN0zQaNxBEbHnyQL9DzupwQQ==
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 semver@5.6.0:
   version "5.6.0"


### PR DESCRIPTION
Implement a starfield using PIXI sprites. Keep track of what stars are on-screen with rbush and only update those ones for greater efficiency. 


TODO: Make the starfield wrap around the edge of the system nicely.

Closes #102 