### PR TITLE
Fix exclusive async systems running only once

### DIFF
--- a/nova_ecs/async_system.ts
+++ b/nova_ecs/async_system.ts
@@ -60,7 +60,7 @@ export class AsyncSystem<StepArgTypes extends readonly ArgTypes[] = readonly Arg
                 if (systemArgs.exclusive && entityStatus.running && canSkip) {
                     return;
                 }
-                entityStatus.running = true;
+                entityStatus.running = true; // Only for exclusive systems.
 
                 // Apply patches from the previous complete run.
                 // Note that this only runs if the entity still exists.
@@ -77,6 +77,7 @@ export class AsyncSystem<StepArgTypes extends readonly ArgTypes[] = readonly Arg
                 delete (stepArgs as any)[Symbol.for('immer-state')];
                 entityStatus.patches = [];
                 if (willSkip) {
+                    entityStatus.running = false;
                     return;
                 }
 


### PR DESCRIPTION
Exclusive async systems that also skip their run when applying patches would only ever run once because they would apply patches but not mark themselves as not running.